### PR TITLE
fix typo in evidence_corpus.py

### DIFF
--- a/evidence_corpus.py
+++ b/evidence_corpus.py
@@ -255,7 +255,7 @@ class XQAEvidenceCorpusTxt(object):
 def main():
     parse = argparse.ArgumentParser("Pre-tokenize the XQA evidence corpus")
     parse.add_argument("--corpus",
-                       choices=["en", "fr", "de", "ru", "pt", "zh", "pl", "uk", "ta"
+                       choices=["en", "fr", "de", "ru", "pt", "zh", "pl", "uk", "ta",
                                 "en_trans_de", "en_trans_zh",
                                 "fr_trans_en", "de_trans_en", "ru_trans_en", "pt_trans_en",
                                 "zh_trans_en", "pl_trans_en", "uk_trans_en", "ta_trans_en"],


### PR DESCRIPTION
In an argparse's choice list, a comma after 'ta' was missing so 'ta' and 'en_trans_de' was concatenated as 'taen_trans_de'. Finally, this script with 'ta' (tamil) cannot be run.

----

error message
```
$ python evidence_corpus.py --corpus ta --n_processes 4
...
usage: Pre-tokenize the XQA evidence corpus [-h] --corpus
                                            {en,fr,de,ru,pt,zh,pl,uk,taen_trans_de,en_trans_zh,fr_trans_en,de_trans_en,ru_trans_en,pt_trans_en,zh_trans_en,pl_trans_en,uk_trans_en,ta_trans_en}
                                            [-n N_PROCESSES] [--wiki_only]
Pre-tokenize the XQA evidence corpus: error: argument --corpus: invalid choice: 'ta' (choose from 'en', 'fr', 'de', 'ru', 'pt', 'zh', 'pl', 'uk', 'taen_trans_de', 'en_trans_zh', 'fr_trans_en', 'de_trans_en', 'ru_trans_en', 'pt_trans_en', 'zh_trans_en', 'pl_trans_en', 'uk_trans_en', 'ta_trans_en')
```